### PR TITLE
update-engine is faster, update-os now increases frequencies and stop…

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -184,6 +184,7 @@ docker run -it --rm \
     export ANKI_BUILD_VERSION=$BUILD_INCREMENT && \
     export AUTO_UPDATE=${AUTO_UPDATE} && \
     ${YOCTO_CLEAN_COMMAND} && \
+    sleep 2 && \
     ${YOCTO_BUILD_COMMAND} && \
     cd ${DIRPATH}/ota && \
     rm -rf ../_build/*.img ../_build/*.stats ../_build/*.ini ../_build/*.enc && \

--- a/poky/build/conf/set_bb_env.sh
+++ b/poky/build/conf/set_bb_env.sh
@@ -219,7 +219,7 @@ function build-prod() {
 }
 
 # cleared every time
-cleanList=(victor wired vic-cloud core-image-anki-initramfs rampost anki-version machine-robot-image system-conf extra-conf vic-engine update-os update-engine wireutils wlan-opensource base-passwd mm-camera initscript-anki)
+cleanList=(victor wired vic-cloud core-image-anki-initramfs rampost anki-version machine-robot-image system-conf extra-conf vic-engine update-os update-engine wireutils wlan-opensource base-passwd mm-camera initscript-anki rebooter)
 
 function clean-oskr() {
   unset_bb_env

--- a/poky/victor/meta-anki/recipes/anki-robot/victor.bb
+++ b/poky/victor/meta-anki/recipes/anki-robot/victor.bb
@@ -104,8 +104,6 @@ do_clean:append() {
     os.system('git -C "%s" clean -Xfd' % s)
 }
 
-
-
 do_compile[pseudo] = "0"
 
 run_victor() {
@@ -179,7 +177,6 @@ run_victor() {
     "$@"
 }
 
-
 do_compile () {
   cd ${S}
 
@@ -237,6 +234,13 @@ do_compile[nostamp] = "1"
 
 do_install () {
   run_victor ${S}/project/victor/scripts/install.sh ${BUILDSRC} ${D}
+  # for if anyone wants to run stuff compiled with vicos-sdk clang++
+  install -d ${D}/usr/lib
+  install -m 0755 ${D}/anki/lib/libc++.so.1 ${D}/usr/lib/
+  install -m 0755 ${D}/anki/lib/libc++abi.so.1 ${D}/usr/lib/
+  install -m 0755 ${D}/anki/lib/libunwind.so.1 ${D}/usr/lib/
+  # no need to ship these twice
+  rm -f ${D}/anki/lib/libc++.so.1 ${D}/anki/lib/libc++abi.so.1 ${D}/anki/lib/libunwind.so.1
 }
 
 do_generate_victor_canned_fs_config () {
@@ -328,3 +332,4 @@ INSANE_SKIP:${PN} = " already-stripped ldflags dev-elf"
 EXCLUDE_FROM_SHLIBS = "1"
 
 FILES:${PN} += "anki/"
+FILES:${PN} += "usr/lib/"

--- a/poky/victor/meta-anki/recipes/update-os/files/update-os.sh
+++ b/poky/victor/meta-anki/recipes/update-os/files/update-os.sh
@@ -73,13 +73,28 @@ chown -R net:anki /run/vic-switchboard
 
 systemctl restart update-engine
 
+echo "Stopping anki-robot.target... (eyes will go dark)"
+systemctl stop anki-robot.target
+
+echo "Upping CPU+RAM frequencies..."
+echo 1267200 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+echo disabled > /sys/kernel/debug/msm_otg/bus_voting  # This prevents USB from pinning RAM to 400MHz
+echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
+echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/mas
+echo 512 > /sys/kernel/debug/msm-bus-dbg/shell-client/slv
+echo 0 > /sys/kernel/debug/msm-bus-dbg/shell-client/ab
+echo active clk2 0 1 max 800000 > /sys/kernel/debug/rpm_send_msg/message # Max RAM freq in KHz = 400MHz
+echo 1 > /sys/kernel/debug/msm-bus-dbg/shell-client/update_request
+
+echo
+
 echo -e "Downloading OS update from:\n$URL"
 
 echo -e -n "\r."
 DOTS=1
 UPDATE_VERSION=""
 while [[ ! -f /run/update-engine/done ]] ; do
-    sleep 3
+    sleep 1
     if [ -z "${UPDATE_VERSION}" -a -f /run/update-engine/manifest.ini ]; then
 	UPDATE_VERSION=`grep update_version /run/update-engine/manifest.ini | awk -F= '{print $NF;}'`
     fi

--- a/poky/victor/meta-vicos/recipes-core/extra-conf/extra-conf/initscripts/mount-data
+++ b/poky/victor/meta-vicos/recipes-core/extra-conf/extra-conf/initscripts/mount-data
@@ -34,7 +34,7 @@ KEY_FILE="/run/userdata.key"
 CONNMAN_DONE_TOKEN=/data/lib/connman/.mount-data
 ROBOT_KEY=/data/etc/robot.pem
 USER_DATA_PARTITION=/dev/block/bootdevice/by-name/userdata
-MOUNT_OPTIONS="defaults,noexec,nosuid,nodev,noatime"
+MOUNT_OPTIONS="defaults,exec,nosuid,nodev,noatime"
 
 mount_data_from_mapped_userdata() {
     mount -o $MOUNT_OPTIONS --source /dev/mapper/userdata --target /data


### PR DESCRIPTION
…s anki-robot.target, /data is mounted as exec, and all the libc++ stuff is copied into /usr/lib in case anyone wants to use arm-oe-linux-gnueabi-clang++-compiled programs without setting LD_LIBRARY_PATH to /anki/lib, fix rebooter.py